### PR TITLE
fix(l10n): the missing CollectionView.en-US.import.toast, and use the "Favorites" translation to comply with current client en-US

### DIFF
--- a/src/views/CollectionView.vue
+++ b/src/views/CollectionView.vue
@@ -12,7 +12,7 @@ en:
     done: Reported successfully. Thank you for your contribution to the health of the Phira community!
   import:
     label: Import
-    toast: Copied to clipboard. Please paste it in "Collections" -> "Import" in-game.
+    toast: Copied to clipboard. Please paste it in "Favorites" -> "Import" in-game.
   visibility:
     title: Visibility
     public: Public

--- a/src/views/CollectionView.vue
+++ b/src/views/CollectionView.vue
@@ -12,7 +12,7 @@ en:
     done: Reported successfully. Thank you for your contribution to the health of the Phira community!
   import:
     label: Import
-    tooltip: Copied to clipboard. Please paste it in "Collections" -> "Import" in-game.
+    toast: Copied to clipboard. Please paste it in "Collections" -> "Import" in-game.
   visibility:
     title: Visibility
     public: Public


### PR DESCRIPTION
- fix #10 
- Also, due to COLLECTIONS means 譜面合集, use Favorites in guide instead
  unless the official want to change operation way or name. 
  Other places are keep original, even if they cause "Collections" means different things for player (Built-in Chart Collections vs Favorites Folders)
  Hope they can find the "star" icon, or the "✰" char could be considered
  
